### PR TITLE
Update to use new FFI convention.

### DIFF
--- a/src/StdIn.Engine.savi
+++ b/src/StdIn.Engine.savi
@@ -1,7 +1,3 @@
-:ffimodule LibPony
-  :fun pony_os_stdin_setup Bool
-  :fun pony_os_stdin_read(buffer CPointer(U8), size USize) USize
-
 // TODO: Documentation
 :class StdIn.Engine
   :is IO.Engine(IO.Action)
@@ -37,7 +33,7 @@
     // We'll use a non-evented core on unix systems where the stdin fd comes
     // from a file instead of from a tty (which is properly evented).
     @_evented_core =
-      if LibPony.pony_os_stdin_setup IO.CoreEngine.new_from_fd_r(@_actor, 0)
+      if _FFI.pony_os_stdin_setup IO.CoreEngine.new_from_fd_r(@_actor, 0)
 
     // If we have no evented core, immediately begin reading by deferring
     // a read action, which will end up repeating until reading is done.
@@ -124,7 +120,7 @@
     if (orig_size == read_buffer.space) error!
 
     // Read into the buffer.
-    bytes_read = LibPony.pony_os_stdin_read(
+    bytes_read = _FFI.pony_os_stdin_read(
       read_buffer.cpointer(orig_size)
       read_buffer.space - orig_size
     )

--- a/src/_FFI.savi
+++ b/src/_FFI.savi
@@ -1,0 +1,3 @@
+:module _FFI
+  :ffi pony_os_stdin_setup Bool
+  :ffi pony_os_stdin_read(buffer CPointer(U8), size USize) USize


### PR DESCRIPTION
We now use the convention of `:module _FFI` with `:ffi` functions.