### PR TITLE
Avoid deprecated `IO.CoreEngine.new_from_fd_r` constructor.

### DIFF
--- a/src/StdIn.Engine.savi
+++ b/src/StdIn.Engine.savi
@@ -32,8 +32,11 @@
     // We use an evented core only if `pony_os_stdin_setup` returns true.
     // We'll use a non-evented core on unix systems where the stdin fd comes
     // from a file instead of from a tty (which is properly evented).
-    @_evented_core =
-      if _FFI.pony_os_stdin_setup IO.CoreEngine.new_from_fd_r(@_actor, 0)
+    @_evented_core = if _FFI.pony_os_stdin_setup (
+      IO.CoreEngine.new(
+        _FFI.pony_asio_event_create(@_actor, 0, AsioEvent.Flags.read, 0, True)
+      )
+    )
 
     // If we have no evented core, immediately begin reading by deferring
     // a read action, which will end up repeating until reading is done.

--- a/src/_FFI.savi
+++ b/src/_FFI.savi
@@ -1,3 +1,7 @@
 :module _FFI
+  :ffi pony_asio_event_create(
+    owner AsioEvent.Actor
+    fd U32, flags U32, nsec U64, noisy Bool
+  ) AsioEvent.ID
   :ffi pony_os_stdin_setup Bool
   :ffi pony_os_stdin_read(buffer CPointer(U8), size USize) USize


### PR DESCRIPTION
We now create our own `AsioEvent.ID` and pass it in.